### PR TITLE
Update TextPad to version 8.5.1

### DIFF
--- a/TextPad/textpad.nuspec
+++ b/TextPad/textpad.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>textpad</id>
-    <version>8.5.0</version>
+    <version>8.5.1</version>
     <title>TextPad</title>
     <authors>Helios Software Solutions</authors>
     <owners>Shannon Barrett</owners>
@@ -12,20 +12,14 @@
     <iconUrl>https://cdn.rawgit.com/shiitake/have-some-chocolate/master/TextPad/icon.png</iconUrl>
     <packageSourceUrl>https://github.com/shiitake/have-some-chocolate</packageSourceUrl>
     <description>TextPad is a powerful, general purpose editor for plain text files. </description>
-    <releaseNotes>##TextPad 8.5.0 (24-Sept-2020)##
-Enhancements:
-
-* Zooming is implemented with default shortcuts Ctrl + and Ctrl -. This can also be done using the new zoom toolbar. The default font size can be reinstated with Ctrl 0.
-* In the File Preferences, there is a new option to save the list of recently used files in workspaces.
-* The Save As dialog is now redisplayed when save is cancelled due to a character encoding conversion error.
-* The setting for visual file comparisons is persisted between sessions.
-
+    <releaseNotes>##TextPad 8.5.1 (21-Jan-2021)##
 Issues resolved:
 
-* CSS syntax highlighting was lost after closing all open .css files, then opening one.
-* The installation directory of JDK 14 was not detected.
-* Tool output buffering prevented display of text a line at a time.
-* The option to choose which instance of TextPad to open a file with was not added to Explorer's context menu.
+* Using the regular expression "^\n" to match empty lines and replace them with nothing did not delete all consecutive empty lines.
+* When opening files, 3-byte UTF-8 characters that straddled multiples of 4KB may have been replaced with "?".
+* Fixed rare crash with the EndOfWord keyboard command at the end of a line.
+* Detection of the location of the WIN32 SDK and MFC folders only worked on English versions of Windows.
+* You can now use the tab key to navigate to the URL on the About dialog box.
     </releaseNotes>
   </metadata>
   <files>

--- a/TextPad/tools/chocolateyinstall.ps1
+++ b/TextPad/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'TextPad'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.textpad.com/file?path=v85/win32/txpeng850-32.zip'
-$url64      = 'https://www.textpad.com/file?path=v85/x64/txpeng850-64.zip'
+$url        = 'https://www.textpad.com/file?path=v85/win32/txpeng851-32.zip'
+$url64      = 'https://www.textpad.com/file?path=v85/x64/txpeng851-64.zip'
 $downloadedZip = Join-Path $toolsDir 'textpad.zip'
 $fileLocation = Join-Path $toolsDir 'setup.exe'
 
@@ -14,9 +14,9 @@ $packageArgs = @{
   filefullpath  = $downloadedZip
   url           = $url
   url64bit      = $url64
-  checksum      = '378AD3E366760C3B1C16B370C28BB14B9535D49E0EBF5385B9F1A61BA3DD3278'
+  checksum      = 'BEB7B84252D025FE34DEBCDF55528868013DA4B60D4D91785BD2186F83EACFF1'
   checksumType  = 'sha256'
-  checksum64    = '9494F3746CA1CF0A98C2CD6E75D0B181FDA41ED9400C7B75BBB2F9C3A1BC5822'
+  checksum64    = 'BD5EE4F4B709FE2CC5135F74EE41E9FF0D65DB513D033F1DFEBB53A6E48F52AC'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Untested, but it should work, since the 8.5.0 update worked fine.

Downloads at https://www.textpad.com/download#TextPad851

Release notes at https://www.textpad.com/relnotes-textpad#v851 :
```
TextPad 8.5.1 (21-Jan-2021)

Issues resolved:

    Using the regular expression "^\n" to match empty lines and replace them with nothing did not delete all consecutive empty lines.
    When opening files, 3-byte UTF-8 characters that straddled multiples of 4KB may have been replaced with "?".
    Fixed rare crash with the EndOfWord keyboard command at the end of a line.
    Detection of the location of the WIN32 SDK and MFC folders only worked on English versions of Windows.
    You can now use the tab key to navigate to the URL on the About dialog box.

```