### PR TITLE
Update TextPad to version 8.6.1

### DIFF
--- a/TextPad/textpad.nuspec
+++ b/TextPad/textpad.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>textpad</id>
-    <version>8.5.1</version>
+    <version>8.6.1</version>
     <title>TextPad</title>
     <authors>Helios Software Solutions</authors>
     <owners>Shannon Barrett</owners>
@@ -12,14 +12,11 @@
     <iconUrl>https://cdn.rawgit.com/shiitake/have-some-chocolate/master/TextPad/icon.png</iconUrl>
     <packageSourceUrl>https://github.com/shiitake/have-some-chocolate</packageSourceUrl>
     <description>TextPad is a powerful, general purpose editor for plain text files. </description>
-    <releaseNotes>##TextPad 8.5.1 (21-Jan-2021)##
+    <releaseNotes>##TextPad 8.6.1 (11-Apr-2021)##
 Issues resolved:
 
-* Using the regular expression "^\n" to match empty lines and replace them with nothing did not delete all consecutive empty lines.
-* When opening files, 3-byte UTF-8 characters that straddled multiples of 4KB may have been replaced with "?".
-* Fixed rare crash with the EndOfWord keyboard command at the end of a line.
-* Detection of the location of the WIN32 SDK and MFC folders only worked on English versions of Windows.
-* You can now use the tab key to navigate to the URL on the About dialog box.
+* Crash while replacing all text in a selected range at the end of a document.
+* The replacement expression "\i{...}" output its results in reverse order.
     </releaseNotes>
   </metadata>
   <files>

--- a/TextPad/textpad.nuspec
+++ b/TextPad/textpad.nuspec
@@ -17,6 +17,19 @@ Issues resolved:
 
 * Crash while replacing all text in a selected range at the end of a document.
 * The replacement expression "\i{...}" output its results in reverse order.
+
+TextPad 8.6.0 (05-Apr-2021)
+
+Enhancements:
+
+* Implemented a new command to repeat the last characters typed. Its default shortcut is Ctrl+. (dot).
+* Speeded up the Replace All command to split very long lines of text.
+* Updated the keywords in the C++ syntax definition file for conformance with version 20.
+
+Issues resolved:
+
+* The Unicode code point U+FFFE is no longer treated as the end of a file.
+* Changes to Preferences were not written to disk until the program terminated.    
     </releaseNotes>
   </metadata>
   <files>

--- a/TextPad/tools/chocolateyinstall.ps1
+++ b/TextPad/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'TextPad'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.textpad.com/file?path=v85/win32/txpeng851-32.zip'
-$url64      = 'https://www.textpad.com/file?path=v85/x64/txpeng851-64.zip'
+$url        = 'https://www.textpad.com/file?path=v86/win32/txpeng861-32.zip'
+$url64      = 'https://www.textpad.com/file?path=v86/x64/txpeng861-64.zip'
 $downloadedZip = Join-Path $toolsDir 'textpad.zip'
 $fileLocation = Join-Path $toolsDir 'setup.exe'
 
@@ -14,9 +14,9 @@ $packageArgs = @{
   filefullpath  = $downloadedZip
   url           = $url
   url64bit      = $url64
-  checksum      = 'BEB7B84252D025FE34DEBCDF55528868013DA4B60D4D91785BD2186F83EACFF1'
+  checksum      = 'C6CC5C3C0D790039D7E087F10C5F4B77483BF7E56664797ABBC4CF47D8A904D4'
   checksumType  = 'sha256'
-  checksum64    = 'BD5EE4F4B709FE2CC5135F74EE41E9FF0D65DB513D033F1DFEBB53A6E48F52AC'
+  checksum64    = '8745E29CA421A1F44C57FE284822DCCF7D9B460D6710CAACACCC073D8953DF85'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Untested, but it should work, since the 8.5.1 and 8.5.0 updates worked fine.

Downloads at https://www.textpad.com/download#TextPad861

Release notes at https://www.textpad.com/relnotes-textpad#v861 :
```
TextPad 8.6.1 (11-April-2021)

Issues resolved:

    Crash while replacing all text in a selected range at the end of a document.
    The replacement expression "\i{...}" output its results in reverse order.

TextPad 8.6.0 (05-April-2021)

Enhancements:

Implemented a new command to repeat the last characters typed. Its default shortcut is Ctrl+. (dot).
Speeded up the Replace All command to split very long lines of text.
Updated the keywords in the C++ syntax definition file for conformance with version 20.
Issues resolved:

The Unicode code point U+FFFE is no longer treated as the end of a file.
Changes to Preferences were not written to disk until the program terminated.


```