### PR TITLE
textpad: Update to version 8.14.2

### DIFF
--- a/TextPad/textpad.nuspec
+++ b/TextPad/textpad.nuspec
@@ -12,7 +12,17 @@
     <iconUrl>https://cdn.rawgit.com/shiitake/have-some-chocolate/master/TextPad/icon.png</iconUrl>
     <packageSourceUrl>https://github.com/shiitake/have-some-chocolate</packageSourceUrl>
     <description>TextPad is a powerful, general purpose editor for plain text files. </description>
-    <releaseNotes>##TextPad 8.14.0 (8-Nov-2022)##
+    <releaseNotes>##TextPad 8.14.2 (22-Nov-2022)##
+Issues resolved:
+
+* In certain circumstances, the Replace All command could lose its place after 5000 replacements.
+* Spaces should not have been rejected in document class names.
+* The Match Case button on the Incremental Finder did not work.
+* Improved the algorithm which determines if foreground and background colors are too similar to be visible.
+* Could not insert more than one separator on the Tools menu.
+* The text cursor width was not scaled for high resolution displays.
+
+##TextPad 8.14.0 (8-Nov-2022)##
 
 Enhancements:
 

--- a/TextPad/tools/chocolateyinstall.ps1
+++ b/TextPad/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'TextPad'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.textpad.com/file?path=v814/win32/txpeng8140-32.zip'
-$url64      = 'https://www.textpad.com/file?path=v814/x64/txpeng8140-64.zip'
+$url        = 'https://www.textpad.com/file?path=v814/win32/txpeng8142-32.zip'
+$url64      = 'https://www.textpad.com/file?path=v814/x64/txpeng8142-64.zip'
 $downloadedZip = Join-Path $toolsDir 'textpad.zip'
 $fileLocation = Join-Path $toolsDir 'setup.exe'
 
@@ -14,9 +14,9 @@ $packageArgs = @{
   filefullpath  = $downloadedZip
   url           = $url
   url64bit      = $url64
-  checksum      = '6ab846b01264f934a01c4cfe04bc709138ac5a23c61904f9faca9d4c421c97f4'
+  checksum      = '16362a3efce6530cd2dd2b469c3326045540f898e6eecb6998727d8b9c7ff663'
   checksumType  = 'sha256'
-  checksum64    = '040df5e4acd0e8f930026107d166c963a60088e0240b9ea9d0c4c4a5cc6205eb'
+  checksum64    = 'e161a2d1641ad07e1e616228f03a85978d1409c0f841db66a007fa639784440e'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Per https://www.textpad.com/relnotes-textpad#v8142
```
TextPad 8.14.2 (22-Nov-2022)
Issues resolved:

In certain circumstances, the Replace All command could lose its place after 5000 replacements.
Spaces should not have been rejected in document class names.
The Match Case button on the Incremental Finder did not work.
Improved the algorithm which determines if foreground and background colors are too similar to be visible.
Could not insert more than one separator on the Tools menu.
The text cursor width was not scaled for high resolution displays.
```