### PR TITLE
Update chocolateyinstall.ps1

### DIFF
--- a/TextPad/v9/tools/chocolateyinstall.ps1
+++ b/TextPad/v9/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'TextPad'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64      = 'https://www.textpad.com/file?path=v91/setupv9.exe'
+$url64      = 'https://www.textpad.com/file?path=v9/setupv9.exe'
 $fileLocation = Join-Path $toolsDir 'setupv9.exe'
 
 $packageArgs = @{


### PR DESCRIPTION
Changed 
$url64      = 'https://www.textpad.com/file?path=v91/setupv9.exe'
to
$url64      = 'https://www.textpad.com/file?path=v9/setupv9.exe'

but still the downloading directly it nows asks for a robot prevention validation, so it might not work